### PR TITLE
Host image files using Amazon S3 storage

### DIFF
--- a/client/constants.js
+++ b/client/constants.js
@@ -1,3 +1,5 @@
+var URL = "https://s3-us-west-2.amazonaws.com/alien-empire/";
+
 // width in pixels of a small planet tile
 var sWid = 212;
 var MOVE_DISTANCE = 5;

--- a/client/loader.js
+++ b/client/loader.js
@@ -9,49 +9,51 @@ var load_assets = function() {
 	if (!is_all_loaded){
 
 		manifest = [
-			{src: "images/game/metal.png", id: "metal"},
-			{src: "images/game/water.png", id: "water"},
-			{src: "images/game/fuel.png", id: "fuel"},
-			{src: "images/game/food.png", id: "food"},
-			{src: "images/game/stars.png", id: "stars"},
-			{src: "images/game/asteroids.png", id: "asteroids"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/metal.png", id: "metal"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/water.png", id: "water"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/fuel.png", id: "fuel"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/food.png", id: "food"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/stars.png", id: "stars"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/asteroids.png", id: "asteroids"},
 
-			{src: "images/game/arrow_red.png", id: "arrow_color0"},
-			{src: "images/game/arrow_blue.png", id: "arrow_color1"},
-			{src: "images/game/arrow_green.png", id: "arrow_color2"},
-			{src: "images/game/arrow_yellow.png", id: "arrow_color3"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/arrow_red.png", id: "arrow_color0"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/arrow_blue.png", id: "arrow_color1"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/arrow_green.png", id: "arrow_color2"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/arrow_yellow.png", id: "arrow_color3"},
 
-			{src: "images/game/mine_red.png", id: "mine0"},
-			{src: "images/game/mine_blue.png", id: "mine1"},
-			{src: "images/game/mine_green.png", id: "mine2"},
-			{src: "images/game/mine_yellow.png", id: "mine3"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/mine_red.png", id: "mine0"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/mine_blue.png", id: "mine1"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/mine_green.png", id: "mine2"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/mine_yellow.png", id: "mine3"},
 
-			{src: "images/game/factory_red.png", id: "factory0"},
-			{src: "images/game/factory_blue.png", id: "factory1"},
-			{src: "images/game/factory_green.png", id: "factory2"},
-			{src: "images/game/factory_yellow.png", id: "factory3"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/factory_red.png", id: "factory0"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/factory_blue.png", id: "factory1"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/factory_green.png", id: "factory2"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/factory_yellow.png", id: "factory3"},
 			
-			{src: "images/game/embassy_red.png", id: "embassy0"},
-			{src: "images/game/embassy_blue.png", id: "embassy1"},
-			{src: "images/game/embassy_green.png", id: "embassy2"},
-			{src: "images/game/embassy_yellow.png", id: "embassy3"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/embassy_red.png", id: "embassy0"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/embassy_blue.png", id: "embassy1"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/embassy_green.png", id: "embassy2"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/embassy_yellow.png", id: "embassy3"},
 
-			{src: "images/game/base_red.png", id: "base0"},
-			{src: "images/game/base_blue.png", id: "base1"},
-			{src: "images/game/base_green.png", id: "base2"},
-			{src: "images/game/base_yellow.png", id: "base3"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/base_red.png", id: "base0"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/base_blue.png", id: "base1"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/base_green.png", id: "base2"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/base_yellow.png", id: "base3"},
 
-			{src: "images/game/fleet_red.png", id: "fleet0"},
-			{src: "images/game/fleet_blue.png", id: "fleet1"},
-			{src: "images/game/fleet_green.png", id: "fleet2"},
-			{src: "images/game/fleet_yellow.png", id: "fleet3"}
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/fleet_red.png", id: "fleet0"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/fleet_blue.png", id: "fleet1"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/fleet_green.png", id: "fleet2"},
+			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/fleet_yellow.png", id: "fleet3"}
 		];
 
 		for ( var p = 1; p <= 29; p++ ) {
-			manifest.push({src: "images/game/planet_" + p + ".png", id: "planet_" + p });
+			manifest.push({src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/planet_" + p + ".png", id: "planet_" + p });
 		}
 
-		loader = new createjs.LoadQueue(false);
+		// loader = new createjs.LoadQueue(false);
+		loader = new createjs.LoadQueue(true, null, true);
+
 		loader.addEventListener("complete", handleComplete);
 		loader.addEventListener("progress", handleProgress);
 		loader.loadManifest(manifest, true);

--- a/client/loader.js
+++ b/client/loader.js
@@ -8,47 +8,49 @@ var load_assets = function() {
 
 	if (!is_all_loaded){
 
+		var url = "https://s3-us-west-2.amazonaws.com/alien-empire/";
+
 		manifest = [
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/metal.png", id: "metal"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/water.png", id: "water"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/fuel.png", id: "fuel"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/food.png", id: "food"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/stars.png", id: "stars"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/asteroids.png", id: "asteroids"},
+			{src: url + "game/metal.png", id: "metal"},
+			{src: url + "game/water.png", id: "water"},
+			{src: url + "game/fuel.png", id: "fuel"},
+			{src: url + "game/food.png", id: "food"},
+			{src: url + "game/stars.png", id: "stars"},
+			{src: url + "game/asteroids.png", id: "asteroids"},
 
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/arrow_red.png", id: "arrow_color0"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/arrow_blue.png", id: "arrow_color1"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/arrow_green.png", id: "arrow_color2"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/arrow_yellow.png", id: "arrow_color3"},
+			{src: url + "game/arrow_red.png", id: "arrow_color0"},
+			{src: url + "game/arrow_blue.png", id: "arrow_color1"},
+			{src: url + "game/arrow_green.png", id: "arrow_color2"},
+			{src: url + "game/arrow_yellow.png", id: "arrow_color3"},
 
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/mine_red.png", id: "mine0"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/mine_blue.png", id: "mine1"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/mine_green.png", id: "mine2"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/mine_yellow.png", id: "mine3"},
+			{src: url + "game/mine_red.png", id: "mine0"},
+			{src: url + "game/mine_blue.png", id: "mine1"},
+			{src: url + "game/mine_green.png", id: "mine2"},
+			{src: url + "game/mine_yellow.png", id: "mine3"},
 
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/factory_red.png", id: "factory0"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/factory_blue.png", id: "factory1"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/factory_green.png", id: "factory2"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/factory_yellow.png", id: "factory3"},
+			{src: url + "game/factory_red.png", id: "factory0"},
+			{src: url + "game/factory_blue.png", id: "factory1"},
+			{src: url + "game/factory_green.png", id: "factory2"},
+			{src: url + "game/factory_yellow.png", id: "factory3"},
 			
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/embassy_red.png", id: "embassy0"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/embassy_blue.png", id: "embassy1"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/embassy_green.png", id: "embassy2"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/embassy_yellow.png", id: "embassy3"},
+			{src: url + "game/embassy_red.png", id: "embassy0"},
+			{src: url + "game/embassy_blue.png", id: "embassy1"},
+			{src: url + "game/embassy_green.png", id: "embassy2"},
+			{src: url + "game/embassy_yellow.png", id: "embassy3"},
 
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/base_red.png", id: "base0"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/base_blue.png", id: "base1"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/base_green.png", id: "base2"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/base_yellow.png", id: "base3"},
+			{src: url + "game/base_red.png", id: "base0"},
+			{src: url + "game/base_blue.png", id: "base1"},
+			{src: url + "game/base_green.png", id: "base2"},
+			{src: url + "game/base_yellow.png", id: "base3"},
 
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/fleet_red.png", id: "fleet0"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/fleet_blue.png", id: "fleet1"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/fleet_green.png", id: "fleet2"},
-			{src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/fleet_yellow.png", id: "fleet3"}
+			{src: url + "game/fleet_red.png", id: "fleet0"},
+			{src: url + "game/fleet_blue.png", id: "fleet1"},
+			{src: url + "game/fleet_green.png", id: "fleet2"},
+			{src: url + "game/fleet_yellow.png", id: "fleet3"}
 		];
 
 		for ( var p = 1; p <= 29; p++ ) {
-			manifest.push({src: "https://s3-us-west-2.amazonaws.com/alien-empire/game/planet_" + p + ".png", id: "planet_" + p });
+			manifest.push({src: url + "game/planet_" + p + ".png", id: "planet_" + p });
 		}
 
 		// loader = new createjs.LoadQueue(false);

--- a/client/loader.js
+++ b/client/loader.js
@@ -8,49 +8,47 @@ var load_assets = function() {
 
 	if (!is_all_loaded){
 
-		var url = "https://s3-us-west-2.amazonaws.com/alien-empire/";
-
 		manifest = [
-			{src: url + "game/metal.png", id: "metal"},
-			{src: url + "game/water.png", id: "water"},
-			{src: url + "game/fuel.png", id: "fuel"},
-			{src: url + "game/food.png", id: "food"},
-			{src: url + "game/stars.png", id: "stars"},
-			{src: url + "game/asteroids.png", id: "asteroids"},
+			{src: URL + "game/metal.png", id: "metal"},
+			{src: URL + "game/water.png", id: "water"},
+			{src: URL + "game/fuel.png", id: "fuel"},
+			{src: URL + "game/food.png", id: "food"},
+			{src: URL + "game/stars.png", id: "stars"},
+			{src: URL + "game/asteroids.png", id: "asteroids"},
 
-			{src: url + "game/arrow_red.png", id: "arrow_color0"},
-			{src: url + "game/arrow_blue.png", id: "arrow_color1"},
-			{src: url + "game/arrow_green.png", id: "arrow_color2"},
-			{src: url + "game/arrow_yellow.png", id: "arrow_color3"},
+			{src: URL + "game/arrow_red.png", id: "arrow_color0"},
+			{src: URL + "game/arrow_blue.png", id: "arrow_color1"},
+			{src: URL + "game/arrow_green.png", id: "arrow_color2"},
+			{src: URL + "game/arrow_yellow.png", id: "arrow_color3"},
 
-			{src: url + "game/mine_red.png", id: "mine0"},
-			{src: url + "game/mine_blue.png", id: "mine1"},
-			{src: url + "game/mine_green.png", id: "mine2"},
-			{src: url + "game/mine_yellow.png", id: "mine3"},
+			{src: URL + "game/mine_red.png", id: "mine0"},
+			{src: URL + "game/mine_blue.png", id: "mine1"},
+			{src: URL + "game/mine_green.png", id: "mine2"},
+			{src: URL + "game/mine_yellow.png", id: "mine3"},
 
-			{src: url + "game/factory_red.png", id: "factory0"},
-			{src: url + "game/factory_blue.png", id: "factory1"},
-			{src: url + "game/factory_green.png", id: "factory2"},
-			{src: url + "game/factory_yellow.png", id: "factory3"},
+			{src: URL + "game/factory_red.png", id: "factory0"},
+			{src: URL + "game/factory_blue.png", id: "factory1"},
+			{src: URL + "game/factory_green.png", id: "factory2"},
+			{src: URL + "game/factory_yellow.png", id: "factory3"},
 			
-			{src: url + "game/embassy_red.png", id: "embassy0"},
-			{src: url + "game/embassy_blue.png", id: "embassy1"},
-			{src: url + "game/embassy_green.png", id: "embassy2"},
-			{src: url + "game/embassy_yellow.png", id: "embassy3"},
+			{src: URL + "game/embassy_red.png", id: "embassy0"},
+			{src: URL + "game/embassy_blue.png", id: "embassy1"},
+			{src: URL + "game/embassy_green.png", id: "embassy2"},
+			{src: URL + "game/embassy_yellow.png", id: "embassy3"},
 
-			{src: url + "game/base_red.png", id: "base0"},
-			{src: url + "game/base_blue.png", id: "base1"},
-			{src: url + "game/base_green.png", id: "base2"},
-			{src: url + "game/base_yellow.png", id: "base3"},
+			{src: URL + "game/base_red.png", id: "base0"},
+			{src: URL + "game/base_blue.png", id: "base1"},
+			{src: URL + "game/base_green.png", id: "base2"},
+			{src: URL + "game/base_yellow.png", id: "base3"},
 
-			{src: url + "game/fleet_red.png", id: "fleet0"},
-			{src: url + "game/fleet_blue.png", id: "fleet1"},
-			{src: url + "game/fleet_green.png", id: "fleet2"},
-			{src: url + "game/fleet_yellow.png", id: "fleet3"}
+			{src: URL + "game/fleet_red.png", id: "fleet0"},
+			{src: URL + "game/fleet_blue.png", id: "fleet1"},
+			{src: URL + "game/fleet_green.png", id: "fleet2"},
+			{src: URL + "game/fleet_yellow.png", id: "fleet3"}
 		];
 
 		for ( var p = 1; p <= 29; p++ ) {
-			manifest.push({src: url + "game/planet_" + p + ".png", id: "planet_" + p });
+			manifest.push({src: URL + "game/planet_" + p + ".png", id: "planet_" + p });
 		}
 
 		// loader = new createjs.LoadQueue(false);

--- a/client/stage.js
+++ b/client/stage.js
@@ -112,6 +112,8 @@ var updatePixelRatio = function() {
 
 	if (window.devicePixelRatio) {
 
+		console.log("updating Pixel Ratio");
+
 		// grab the width and height from canvas
 		var height = canvas.getAttribute('height');
 		var width = canvas.getAttribute('width');
@@ -133,6 +135,9 @@ var updatePixelRatio = function() {
 };
 
 var setBackgroundSize = function() {
+
+	console.log("updating Pixel Ratio");
+
 	var scaleX = window.innerWidth / backgroundW;
 	var scaleY = window.innerHeight / backgroundH;
 	backgroundScale = scaleX > scaleY ? scaleX : scaleY;

--- a/client/stage.js
+++ b/client/stage.js
@@ -59,7 +59,7 @@ var init_background = function() {
 	stage.addChild(background);
 
 	backLoader = new createjs.LoadQueue(false);
-	backLoader.loadFile({src: "https://s3-us-west-2.amazonaws.com/alien-empire/images/space_background.jpg", id: "space_background"});
+	backLoader.loadFile({src: URL + "images/space_background.jpg", id: "space_background"});
 	backLoader.addEventListener("complete", drawBackground);
 };
 

--- a/client/stage.js
+++ b/client/stage.js
@@ -59,7 +59,7 @@ var init_background = function() {
 	stage.addChild(background);
 
 	backLoader = new createjs.LoadQueue(false);
-	backLoader.loadFile({src: "images/space_background.jpg", id: "space_background"});
+	backLoader.loadFile({src: "https://s3-us-west-2.amazonaws.com/alien-empire/images/space_background.jpg", id: "space_background"});
 	backLoader.addEventListener("complete", drawBackground);
 };
 


### PR DESCRIPTION
Sending all our images (and later, sound files) from modulus eats up a lot of space and has hit some serious latency at times. Modulus support suggested moving image assets to an S3 server instead.
