### PR TITLE
Fixed bug with agents getting duplicated, slowing processing

### DIFF
--- a/client/agents.js
+++ b/client/agents.js
@@ -3,7 +3,7 @@
  * current planetid (either a number or undefined). 
  */
 
-var initAgents = function(planetid) {
+var initAgents = function() {
 
 	for( var agentid in clientGame.game.board.agents ) {
 
@@ -15,10 +15,9 @@ var initAgents = function(planetid) {
 		agentshape.name = AGT_ENGLISH[ agenttype ] + player;
 
 		var agentImg = loader.getResult( AGT_ENGLISH[agenttype] + player );
-		agentshape.graphics.beginBitmapFill(agentImg, "no-repeat").drawRect(0, 0, agentImg.width, agentImg.height);
+		agentshape.graphics.beginBitmapFill(agentImg, "no-repeat").drawRect(0, 0, 105, 105);
 		agentshape.visible = false;
 		agentshape.mouseEnabled = false; //default this to false, otherwise it slows processing down
-		// agentshape.cache(0, 0, agtWid, agtWid);
 
 		board.addChild( agentshape );
 	}
@@ -49,13 +48,13 @@ var updateAgents = function(planetid) {
 		var agenttype = agent.agenttype;
 
 		var agentshape = board.getChildByName(AGT_ENGLISH[agenttype] + player);
-		board.setChildIndex(agentshape, board.getNumChildren()-1);
+		
+		board.setChildIndex(agentshape, board.getNumChildren() - 1);
 
 		agentshape.visible = true;
+
 		agentshape.x = tiles[planetid].x + agentsX;
 		agentshape.y = tiles[planetid].y + agentsY;
-
-		// agentshape.updateCache();
 
 		agentsX += agtWid + space;
 	}

--- a/client/game_board.js
+++ b/client/game_board.js
@@ -157,6 +157,7 @@ var updateBoard = function() {
 			updateTileInteractivity(p);
 			updateTileImage(p);
 			updateFleets(p);
+			updateAgents(p);
 		}
 
 	stage.update();

--- a/client/tile.js
+++ b/client/tile.js
@@ -79,7 +79,6 @@ var drawTile = function(planetid) {
 var updateTileImage = function(planetid) {
 	drawResources(planetid);
 	drawOrbitStructures(planetid);
-	drawAgents(planetid);
 };
 
 /**
@@ -194,7 +193,7 @@ var drawStars = function( planetid, img_width ) {
 	stars.x = starOffsetX * -1;
 	stars.y = starOffsetY * -1;
 
-	stars.cache(starOffsetX, starOffsetY, img_width, img_width);
+	// stars.cache(starOffsetX, starOffsetY, img_width, img_width);
 };
 
 /**
@@ -282,8 +281,6 @@ var drawPlanet = function( planetid ) {
 
 		picture.x = offsetX * -1;
 		picture.y = offsetY * -1;
-
-		picture.cache(offsetX, offsetY, planetImg.width, planetImg.height);
 	}
 };
 
@@ -504,8 +501,6 @@ var drawDarkScreen = function(planetid, img_width) {
 	if(planets[planetid].explored) {
 		darkscreen.visible = false;
 	}
-
-	darkscreen.cache(0, 0, img_width, img_width);
 };
 
 var showDarkScreen = function( planetid ) {
@@ -531,7 +526,6 @@ var drawLightScreen = function(planetid, img_width) {
 	lightscreen.graphics.drawRect(0, 0, img_width, img_width);
 	lightscreen.visible = false;
 
-	lightscreen.cache(0, 0, img_width, img_width);
 };
 
 var showLightscreen = function( planetid ) {


### PR DESCRIPTION
Found a problem where drawAgents (and initAgents) was getting called every time tiles got updated, causing the board to have thousands of children, causing a huge slowdown in processing
